### PR TITLE
Backport comint-clear-buffer

### DIFF
--- a/emacs.d/bivio-init.el
+++ b/emacs.d/bivio-init.el
@@ -160,7 +160,7 @@
     (interactive)
     (let ((comint-buffer-maximum-size 0))
       (comint-truncate-buffer)))
-  (define-key global-map "\C-c\M-o" 'bivio-comint-clear-buffer))
+  (define-key shell-mode-map "\C-c\M-o" 'bivio-comint-clear-buffer))
 
 (defun b-ffap-with-line ()
   "Go to file under cursor possibly with line number."

--- a/emacs.d/bivio-init.el
+++ b/emacs.d/bivio-init.el
@@ -153,6 +153,15 @@
       (unless (eq nil process)
         (set-process-window-size process (window-height) (window-width))))))
 
+
+(unless (fboundp 'comint-clear-buffer)
+  (defun bivio-comint-clear-buffer ()
+    "Clear the comint buffer. Remove when we are on emacs >= 25"
+    (interactive)
+    (let ((comint-buffer-maximum-size 0))
+      (comint-truncate-buffer)))
+  (define-key global-map "\C-c\M-o" 'bivio-comint-clear-buffer))
+
 (defun b-ffap-with-line ()
   "Go to file under cursor possibly with line number."
   (interactive)


### PR DESCRIPTION
Emacs >= 25 has comint-clear-buffer bound to C-c M-o. Centos7 uses
emacs 24 so make comint-clear-buffer avaialble there (anywhere it
doesn't exist).