### PR TITLE
Fix #10: delete branches with no remote tracking branch

### DIFF
--- a/bashrc.d/zz-20-dev.sh
+++ b/bashrc.d/zz-20-dev.sh
@@ -107,6 +107,17 @@ gcl() {
     fi
 }
 
+gbranchdel() {
+    # Delete local branches that no longer have a remote tracking branch
+    # https://stackoverflow.com/a/33548037/5518313
+    git fetch --prune
+    declare b
+    for b in $(git for-each-ref --format '%(refname) %(upstream:track)' refs/heads \
+                   | awk '$2 == "[gone]" {sub("refs/heads/", "", $1); print $1}'); do
+        git branch -D $b
+    done
+}
+
 gst() {
     git status -s "$@"
 }


### PR DESCRIPTION
To delete all merged branches folks reccomend using `git branch --merged` to source them. Parsing `git branch` is not reccomended https://stackoverflow.com/a/26152574/5518313.  Likewise, we do squash merges. In those merges the original branch is left intact and from the perspective of git unmerged. So, --merged won't pick them up.

After we merge we delete branches. So, we can delete all local tracking branches where the remote branch has been deleted. This has the added benefit that if a branch is unmerged but deleted (ex a pr was proposed but ultimately not merged) then we will clean up that branch too.

This doesn't work on centos7. The git there doesn't support the `:track` syntax.