### PR TITLE
WIP radiasoft/download#350: configure git pull to not check safe directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,11 +42,7 @@ for repo in home-env \
     if [[ -d $repo ]]; then
         (
             cd "$repo"
-            if [[ ${bivio_home_env_ignore_git_dir_ownership:+1} ]]; then
-                git -c 'safe.directory=*'  pull  -q
-            else
-                git pull -q
-            fi
+            git ${bivio_home_env_ignore_git_dir_ownership:+-c 'safe.directory=*'} pull -q
         )
     else
         u=https://github.com/biviosoftware/$repo.git

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,11 @@ for repo in home-env \
     if [[ -d $repo ]]; then
         (
             cd "$repo"
-            git pull -q
+            if [[ ${bivio_home_env_ignore_git_dir_ownership:+1} ]]; then
+                git -c 'safe.directory=*'  pull  -q
+            else
+                git pull -q
+            fi
         )
     else
         u=https://github.com/biviosoftware/$repo.git


### PR DESCRIPTION
Fedora 36 has git 2.39.2 which checks to make sure that the user running the git operations is the owner of the git directory (more explanation https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9). This causes problems when working over an NFS mount because from git's perspective the user on the NFS client may not be the owner of the directory. The git pull here is the only git operation we do in our install that is impacted so allow configuration to be supplied to turn off the check.