### PR TITLE
Fix #123 radia_run uses $RADIA_RUN_SERVER 

### DIFF
--- a/bashrc.d/zz-10-base.sh
+++ b/bashrc.d/zz-10-base.sh
@@ -358,7 +358,10 @@ radia_run() {
     if [[ ! $u || $u == github ]]; then
         u=https://radia.run
     fi
-    curl --fail --location --silent --show-error "$u" | install_server="$u" bash --login "${install_debug:+-x}" -s "$@"
+    curl --fail --location --show-error --silent "$u" \
+        | install_server="$u" \
+        install_depot_server="${install_depot_server:-${RADIA_RUN_DEPOT_SERVER:-}}" \
+        bash "${install_debug:+-x}" -s "$@"
 }
 
 if [[ $(type -p emacs) && $(type -p emacsclient) ]]; then

--- a/bashrc.d/zz-10-base.sh
+++ b/bashrc.d/zz-10-base.sh
@@ -22,7 +22,7 @@ if [[ ! ${bivio_color:-} ]]; then
 fi
 
 # Undo bivio functions from /etc/bashrc.d
-for f in bconf b bu ba bi bihs ctd g gp $(compgen -A function | egrep '^(b_|bivio_)'); do
+for f in bconf b bu ba bi bihs ctd g gp $(compgen -A function | grep -E '^(b_|bivio_)'); do
     if [[ $f != bivio_not_src_home_env ]]; then
         unset -f "$f"
     fi
@@ -350,7 +350,7 @@ function gp() {
         --exclude='.#*' \
         --exclude=bOP.pm \
         "$x" "${@-.}" |
-	egrep -v '/files/artisans/plain/f/bOP'
+	grep -E -v '/files/artisans/plain/f/bOP'
 }
 
 radia_run() {

--- a/bashrc.d/zz-10-base.sh
+++ b/bashrc.d/zz-10-base.sh
@@ -360,7 +360,6 @@ radia_run() {
     fi
     curl --fail --location --show-error --silent "$u" \
         | install_server="$u" \
-        install_depot_server="${install_depot_server:-${RADIA_RUN_DEPOT_SERVER:-}}" \
         bash "${install_debug:+-x}" -s "$@"
 }
 

--- a/bashrc.d/zz-10-base.sh
+++ b/bashrc.d/zz-10-base.sh
@@ -359,7 +359,7 @@ radia_run() {
         u=https://radia.run
     fi
     curl --fail --location --show-error --silent "$u" \
-        | install_server="$u" \
+        | install_server="${install_server:-${RADIA_RUN_SERVER:-}}" \
         bash "${install_debug:+-x}" -s "$@"
 }
 

--- a/bashrc.d/zz-10-base.sh
+++ b/bashrc.d/zz-10-base.sh
@@ -354,11 +354,11 @@ function gp() {
 }
 
 radia_run() {
-    declare u=${install_server:-}
+    declare u=${install_server:-${RADIA_RUN_SERVER:-}}
     if [[ ! $u || $u == github ]]; then
         u=https://radia.run
     fi
-    curl -s -S -L "$u" | bash -l -s "$@"
+    curl --fail --location --silent --show-error "$u" | install_server="$u" bash --login "${install_debug:+-x}" -s "$@"
 }
 
 if [[ $(type -p emacs) && $(type -p emacsclient) ]]; then

--- a/bashrc.d/zz-10-base.sh
+++ b/bashrc.d/zz-10-base.sh
@@ -360,7 +360,7 @@ radia_run() {
     fi
     curl --fail --location --show-error --silent "$u" \
         | install_server="${install_server:-${RADIA_RUN_SERVER:-}}" \
-        bash "${install_debug:+-x}" -s "$@"
+        bash ${install_debug:+-x} -s "$@"
 }
 
 if [[ $(type -p emacs) && $(type -p emacsclient) ]]; then


### PR DESCRIPTION
- radia_run always has `install_server` if set else sets `install_server=${RADIA_RUN_SERVER:-https://radia.run`.
  While `github` is still valid, we are switching to `https://radia.run` to all repos served to be consistent.
- e/fgrep use grep -E/F; deprecated in Fedora 42
