### PR TITLE
Fix #134 force NVM_DIR to be ~/.local/nvm

### DIFF
--- a/bashrc.d/zz-10-base.sh
+++ b/bashrc.d/zz-10-base.sh
@@ -321,9 +321,7 @@ if [[ ${BIVIO_WANT_PERL:-} ]]; then
     fi
 fi
 
-if [[ ! ${NVM_DIR:-} ]]; then
-    export NVM_DIR=$HOME/.local/nvm
-fi
+export NVM_DIR=$HOME/.local/nvm
 if [[ -r $NVM_DIR/nvm.sh ]]; then
     source "$NVM_DIR"/nvm.sh
 fi


### PR DESCRIPTION
Build will fail if su'd to the user, because NVM_DIR already set in other user